### PR TITLE
Added externalActivityId parameter to EventActivityScope; added tests for same

### DIFF
--- a/EventSourceProxy.Tests/EventActivityScopeTests.cs
+++ b/EventSourceProxy.Tests/EventActivityScopeTests.cs
@@ -53,6 +53,73 @@ namespace EventSourceProxy.Tests
 			}
 		}
 
+		[Test]
+		public void NewScopeWithExistingActivityIdShouldUseCorrectActivityId()
+		{
+			Guid externalGuid = Guid.Parse("c2cbe3e9-53ee-440c-b16b-2dec89df7202");
+			using (EventActivityScope scope1 = new EventActivityScope(externalGuid))
+			{
+				Assert.AreEqual(scope1.ActivityId, externalGuid);
+			}
+		}
+
+		[Test]
+		public void ReuseScopeShouldReuseExternalActivityId()
+		{
+			Guid externalGuid = Guid.Parse("b423a74f-f5c7-4707-8555-552567ec446a");
+			using (EventActivityScope scope1 = new EventActivityScope(externalGuid))
+			{
+				Assert.AreEqual(scope1.ActivityId, externalGuid);
+				// make sure we don't have an outer activity, but do have an inner activity
+				Assert.AreEqual(Guid.Empty, scope1.PreviousActivityId);
+				Assert.AreNotEqual(Guid.Empty, scope1.ActivityId);
+
+				using (EventActivityScope scope2 = new EventActivityScope(true))
+				{
+					Assert.AreEqual(scope1.ActivityId, scope2.PreviousActivityId);
+					Assert.AreEqual(scope1.ActivityId, scope2.ActivityId);
+				}
+			}
+		}
+
+		[Test]
+		public void NewScopeShouldGenerateNewActivityIdWhenParentHasExternalActivityId()
+		{
+			Guid externalGuid = Guid.Parse("adc174e5-6f7b-4280-a4a4-8d8550ab4f89");
+			using (EventActivityScope scope1 = new EventActivityScope(externalGuid))
+			{
+				Assert.AreEqual(scope1.ActivityId, externalGuid);
+				// make sure we don't have an outer activity, but do have an inner activity
+				Assert.AreEqual(Guid.Empty, scope1.PreviousActivityId);
+				Assert.AreNotEqual(Guid.Empty, scope1.ActivityId);
+
+				using (EventActivityScope scope2 = new EventActivityScope())
+				{
+					Assert.AreEqual(scope1.ActivityId, scope2.PreviousActivityId);
+					Assert.AreNotEqual(scope1.ActivityId, scope2.ActivityId);
+				}
+			}
+		}
+
+		[Test]
+		public void NewScopeWithExternalActivityIdShouldUseCorrectActivityId()
+		{
+			Guid externalGuid = Guid.Parse("64a49a09-c775-4a91-b4ec-91a9a6e3caeb");
+			using (EventActivityScope scope1 = new EventActivityScope())
+			{
+				// make sure we don't have an outer activity, but do have an inner activity
+				Assert.AreEqual(Guid.Empty, scope1.PreviousActivityId);
+				Assert.AreNotEqual(Guid.Empty, scope1.ActivityId);
+
+				using (EventActivityScope scope2 = new EventActivityScope(externalGuid))
+				{
+					Assert.AreEqual(scope2.ActivityId, externalGuid);
+					Assert.AreEqual(scope1.ActivityId, scope2.PreviousActivityId);
+					Assert.AreNotEqual(scope1.ActivityId, scope2.ActivityId);
+				}
+			}
+		}
+
 		#region Async Tests
 		public interface ILogForAsync
 		{

--- a/EventSourceProxy/EventActivityScope.cs
+++ b/EventSourceProxy/EventActivityScope.cs
@@ -66,6 +66,19 @@ namespace EventSourceProxy
 			else
 				_activityId = _previousActivityId;
 		}
+
+		/// <summary>
+		/// Initializes a new instance of the EventActivityScope class with a given Activity ID.
+		/// </summary>
+		/// <param name="externalActivityId">
+		/// The existing Activity ID to use.
+		/// </param>
+		public EventActivityScope(Guid externalActivityId)
+		{
+			_previousActivityId = GetActivityId();
+			_activityId = externalActivityId;
+			SetActivityId(_activityId);
+		}
 		#endregion
 
 		#region Properties


### PR DESCRIPTION
We need to create an EventActivityScope with a given activity guid and so I've implemented a very simple mechanism for doing so. 

I think ETW provides some sort of build in mechanism for doing this automagically somehow but I couldn't find any useful information available about this. Hence the solution embodied by this pull request :)
