### PR TITLE
ParameterProvider maps subclass properties

### DIFF
--- a/EventSourceProxy.Tests/ParameterProviderTests.cs
+++ b/EventSourceProxy.Tests/ParameterProviderTests.cs
@@ -459,5 +459,35 @@ namespace EventSourceProxy.Tests
 			Assert.AreEqual(1, TPPWithContext.ContextCalls);
 		}
 		#endregion
+
+		public class BaseClass
+		{
+			public string Message { get; set; }
+		}
+
+		public class SubClass : BaseClass
+		{
+		}
+
+		public interface ISubClassEventSource
+		{
+			void TestMessage(SubClass sc);
+		}
+
+		[Test]
+		public void ParameterProviderAddsMappingForSubClassWhenBaseClassIsMapped()
+		{
+			var tpp = new TraceParameterProvider();
+			tpp.ForAnything()
+				.With<BaseClass>()
+				.Trace(c => c.Message);
+
+			var proxy2 = new TypeImplementer(typeof(ISubClassEventSource), tpp).EventSource;                
+
+			Assert.DoesNotThrow(delegate
+			{
+				var proxy = new TypeImplementer(typeof(ISubClassEventSource), tpp).EventSource;                
+			});
+		}
 	}
 }

--- a/EventSourceProxy/ParameterDefinition.cs
+++ b/EventSourceProxy/ParameterDefinition.cs
@@ -56,7 +56,7 @@ namespace EventSourceProxy
 				{
 					if (converter.Parameters.Count != 1)
 						throw new ArgumentException("The conversion expression must take one parameter.", "converter");
-					if (SourceType != converter.Parameters[0].Type)
+					if (SourceType != converter.Parameters[0].Type && !SourceType.IsSubclassOf(converter.Parameters[0].Type))
 						throw new ArgumentException("The conversion expression must match the type of the parameter.", "converter");
 				}
 			}


### PR DESCRIPTION
Prior to this commit, if you create a TraceParameterProvider that maps
properties for a base class, then create an Interface for an EventSource
that has a method with a parameter that is a subclass of that base
class, an exception would be thrown.

This is because ParameterBuilder<T>.Matches would allow for a subclass
to match, but the ParameterDefinition constructor would not.

This update changes the ParameterDefinition constructor to allow
subclasses to match a base class.

A test is included to demonstrate the problem.
